### PR TITLE
Bumped version number to v1.0.0-beta.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name"          : "node-red-contrib-rtcomm",
-    "version"       : "v1.0.0-beta.3",
+    "version"       : "v1.0.0-beta.4",
     "description"   : "Node-RED nodes that interface with Rtcomm services from a WebSphere Liberty Profile Server.",
     "dependencies"  : {
         "rtcomm"   : "v1.0.0-beta.3"


### PR DESCRIPTION
Bumped version number to v1.0.0-beta.4 because of an npm publish mistake.
