### PR TITLE
Resolve issue #12 removing "callControl" from the Rtcomm topic path

### DIFF
--- a/45-rtcomm.html
+++ b/45-rtcomm.html
@@ -135,7 +135,7 @@
         <input type="text" id="node-input-broker">
     </div>
     <div class="form-row">
-        <label for="node-input-topic"><i class="icon-tasks"></i> 3PCC Topic</label>
+        <label for="node-input-topic"><i class="icon-tasks"></i> Root Topic</label>
         <input type="text" id="node-input-topic" placeholder="Topic">
     </div>
     <div class="form-row">

--- a/45-rtcomm.js
+++ b/45-rtcomm.js
@@ -146,7 +146,7 @@ module.exports = function(RED) {
     // The 3PCC node definition
 	function Rtcomm3PCCNode(n) {
         RED.nodes.createNode(this,n);
-        this.topic = n.topic || '/rtcomm/ThirdPartyCC';
+        this.topic = (n.topic || '/rtcomm/') + 'callControl';
         this.broker = n.broker;
         this.brokerConfig = RED.nodes.getNode(this.broker);
         this.thirdPCC = null;


### PR DESCRIPTION
Changed the 3ppc topic tag  to Root Topic on the node-red node. Also added callControl to the 3ppc so it does not have to be specified and the only thing to be used it the rtcomm root topic.