### PR TITLE
Modified rtcomm (node) dependency to 1.0.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 *.md.html
 .project
 .settings
+.DS_Store
+node_modules

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,1 @@
+If you'd like to contribute to this project, see our [contributor guidelines](https://github.com/WASdev/wasdev.github.io/blob/master/CONTRIBUTING.md).

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "version"       : "v1.0.0",
     "description"   : "Node-RED nodes that interface with Rtcomm services from a WebSphere Liberty Profile Server.",
     "dependencies"  : {
-        "rtcomm"   : "v1.0.0"
+        "rtcomm"   : "v1.0.1"
     },
     "license": "Apache",
     "repository" : { 


### PR DESCRIPTION
This change is needed to pick up the latest release of the mqtt client that supports web sockets.